### PR TITLE
Improve loading experience

### DIFF
--- a/quirrus-core/src/main/kotlin/org/sonarsource/dev/quirrus/JsonTypes.kt
+++ b/quirrus-core/src/main/kotlin/org/sonarsource/dev/quirrus/JsonTypes.kt
@@ -18,7 +18,7 @@ data class Builds(val edges: List<Edge>)
 data class Edge(val node: BuildNode)
 
 @Serializable
-data class BuildNode(val id: String, val buildCreatedTimestamp: Long, val tasks: List<Task>, val branch: String)
+data class BuildNode(val id: String, val buildCreatedTimestamp: Long, val changeTimestamp: Long, val tasks: List<Task>, val branch: String)
 
 @Serializable
 data class Task(val id: String, val name: String, val creationTimestamp: Long, val status: String = "NONE", val firstFailedCommand: FirstFailedCommand? = null, val automaticReRun: Boolean = false, val artifacts: List<Artifacts> = emptyList())

--- a/quirrus-core/src/main/kotlin/org/sonarsource/dev/quirrus/RequestBuilder.kt
+++ b/quirrus-core/src/main/kotlin/org/sonarsource/dev/quirrus/RequestBuilder.kt
@@ -6,9 +6,10 @@ object RequestBuilder {
     fun logDownloadLink(taskId: String, logName: String) =
         "https://api.cirrus-ci.com/v1/task/$taskId/logs/$logName"
 
-    fun tasksQuery(repositoryId: String, branchName: String?, numberOfLatestBuilds: Int = 1): Kraph {
+    fun tasksQuery(repositoryId: String, branchName: String?, numberOfLatestBuilds: Int = 1, beforeTimestamp: Long? = null): Kraph {
         val buildsArgs: MutableMap<String, Any> = mutableMapOf("last" to numberOfLatestBuilds)
         branchName?.let { buildsArgs["branch"] = it }
+        beforeTimestamp?.let { buildsArgs["before"] = "$it" }
 
         return Kraph {
             query {
@@ -18,6 +19,7 @@ object RequestBuilder {
                             fieldObject("node") {
                                 field("id")
                                 field("buildCreatedTimestamp")
+                                field("changeTimestamp")
                                 field("branch")
                                 fieldObject("tasks") {
                                     field("name")

--- a/quirrus-core/src/main/kotlin/org/sonarsource/dev/quirrus/api/LogDownloader.kt
+++ b/quirrus-core/src/main/kotlin/org/sonarsource/dev/quirrus/api/LogDownloader.kt
@@ -45,8 +45,8 @@ class LogDownloader(private val apiConfiguration: ApiConfiguration) {
         }.toList()
     }
 
-    suspend fun getLastNBuilds(repositoryId: String, branch: String?, numberOfBuilds: Int) =
-        apiConfiguration.post(RequestBuilder.tasksQuery(repositoryId, branch, numberOfBuilds)).let {
+    suspend fun getLastNBuilds(repositoryId: String, branch: String?, numberOfBuilds: Int, beforeTimestamp: Long? = null) =
+        apiConfiguration.post(RequestBuilder.tasksQuery(repositoryId, branch, numberOfBuilds, beforeTimestamp)).let {
             it to it.body<RepositoryApiResponse>()
         }
 

--- a/wallboard/src/main/kotlin/com/sonarsource/dev/quirrus/wallboard/Main.kt
+++ b/wallboard/src/main/kotlin/com/sonarsource/dev/quirrus/wallboard/Main.kt
@@ -12,7 +12,7 @@ import java.nio.file.Path
 
 val API_CONF = ApiConfiguration(
     authenticator = { request -> request.authenticateWithConfigFile(AUTH_CONF_FILE) },
-    requestTimeoutOverride = 60_000
+    requestTimeoutOverride = 30_000
 )
 
 val AUTH_CONF_FILE = Path.of(System.getenv("HOME"), ".quirrus", "auth.conf")

--- a/wallboard/src/main/kotlin/com/sonarsource/dev/quirrus/wallboard/WallboardApp.kt
+++ b/wallboard/src/main/kotlin/com/sonarsource/dev/quirrus/wallboard/WallboardApp.kt
@@ -70,7 +70,8 @@ fun WallboardApp() {
     var repoTextFieldVal by remember { mutableStateOf(repo) }
     var clickPosition by remember { mutableStateOf(-1f) }
     val taskListScrollState = rememberScrollState(0)
-    var autoRefresh by remember { mutableStateOf(autoRefreshEnabled) }
+    //var autoRefresh by remember { mutableStateOf(autoRefreshEnabled) }
+    var autoRefresh = false
     var backgroundRefreshCounter by remember { mutableStateOf(0L) }
     var lastSelectedTab: String? by remember { mutableStateOf(null) }
     var backgroundLoadingInProgress by remember { mutableStateOf(false) }
@@ -240,7 +241,7 @@ fun WallboardApp() {
                         )
                     }
 
-                    Row(
+                    /*Row(
                         verticalAlignment = Alignment.CenterVertically,
                         modifier = Modifier
                             .padding(start = 5.dp, end = 5.dp, top = 5.dp)
@@ -253,7 +254,7 @@ fun WallboardApp() {
                             onCheckedChange = { changeAutoReloadSetting() },
                         )
                         Text("Auto-refresh")
-                    }
+                    }*/
                 }
 
                 Column(modifier = Modifier.weight(0.9f)) {

--- a/wallboard/src/main/kotlin/com/sonarsource/dev/quirrus/wallboard/WallboardApp.kt
+++ b/wallboard/src/main/kotlin/com/sonarsource/dev/quirrus/wallboard/WallboardApp.kt
@@ -24,7 +24,6 @@ import androidx.compose.runtime.mutableStateMapOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
-import androidx.compose.runtime.snapshots.SnapshotStateMap
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -36,8 +35,6 @@ import com.sonarsource.dev.quirrus.wallboard.WallboardConfig.repo
 import com.sonarsource.dev.quirrus.wallboard.data.BuildWithTasks
 import com.sonarsource.dev.quirrus.wallboard.data.CirrusData
 import com.sonarsource.dev.quirrus.wallboard.data.DataProcessing
-import com.sonarsource.dev.quirrus.wallboard.data.EnrichedTask
-import com.sonarsource.dev.quirrus.wallboard.data.Status
 import com.sonarsource.dev.quirrus.wallboard.data.StatusCategory
 import com.sonarsource.dev.quirrus.wallboard.data.TaskDiffData
 import com.sonarsource.dev.quirrus.wallboard.guicomponents.ErrorScreen
@@ -49,12 +46,7 @@ import com.sonarsource.dev.quirrus.wallboard.guicomponents.SideTab
 import com.sonarsource.dev.quirrus.wallboard.guicomponents.TaskList
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
-import org.sonarsource.dev.quirrus.BuildNode
-import org.sonarsource.dev.quirrus.Task
-import org.sonarsource.dev.quirrus.api.Common
-import org.sonarsource.dev.quirrus.gui.GuiAuthenticationHelper
 import java.util.Locale
-import javax.net.ssl.SSLHandshakeException
 
 var cirrusData = CirrusData(API_CONF)
 
@@ -83,6 +75,8 @@ fun WallboardApp() {
     var lastSelectedTab: String? by remember { mutableStateOf(null) }
     var backgroundLoadingInProgress by remember { mutableStateOf(false) }
     val tasksWithDiffs by remember { mutableStateOf(mutableStateMapOf<String, TaskDiffData?>()) }
+    val branchState by remember { mutableStateOf(mutableStateMapOf<String, AppState>()) }
+    val errors by remember { mutableStateOf(mutableStateMapOf<String, String>()) }
 
     fun saveConfig() {
         with(WallboardConfig) {
@@ -94,17 +88,23 @@ fun WallboardApp() {
     }
 
     fun triggerReload() {
+        lastTasks.clear()
+        lastTasks.putAll(branches.map { it to null })
+        branchState.clear()
+        branchState.putAll(branches.map { it to AppState.LOADING })
         reloadData(
             state,
             repoTextFieldVal,
             branches,
             selectedTab,
+            lastTasks,
             { state = it },
             { error = it },
             { repoTextFieldVal = it },
-            { lastTasks = SnapshotStateMap<String, List<BuildWithTasks>?>().apply { putAll(it) } },
             { selectedTab = it },
             { saveConfig() },
+            { branch, state -> branchState[branch] = state },
+            { branch, error -> errors[branch] = error }
         )
         updateRulesWithDiff(
             DataProcessing.extractTasksThatRequireLazyLoadingOfDiffRules(dataByBranch, tasksWithDiffs),
@@ -258,10 +258,14 @@ fun WallboardApp() {
 
                 Column(modifier = Modifier.weight(0.9f)) {
                     Row {
-                        when (state) {
+                        if (state == AppState.INIT){
+                            triggerReload()
+                            return@Row
+                        }
+
+                        when (branchState[selectedTab]) {
                             AppState.LOADING -> LoadingScreen()
-                            AppState.ERROR -> ErrorScreen(error)
-                            AppState.INIT -> triggerReload()
+                            AppState.ERROR -> ErrorScreen(errors[selectedTab] ?: "NULL")
                             else -> dataByBranch[selectedTab]?.let { taskHistory ->
                                 Column(
                                     modifier = Modifier

--- a/wallboard/src/main/kotlin/com/sonarsource/dev/quirrus/wallboard/data/CirrusData.kt
+++ b/wallboard/src/main/kotlin/com/sonarsource/dev/quirrus/wallboard/data/CirrusData.kt
@@ -8,8 +8,8 @@ import org.sonarsource.dev.quirrus.api.ApiException
 import org.sonarsource.dev.quirrus.api.LogDownloader
 
 class CirrusData(val apiConfig: ApiConfiguration) {
-    private suspend fun getLastPeachBuilds(repo: String, branch: String, numberOfBuilds: Int = 1) =
-        LogDownloader(apiConfig).getLastNBuilds(repo, branch, numberOfBuilds).let { (response, repositoryApiResponse) ->
+    suspend fun getLastPeachBuilds(repo: String, branch: String, numberOfBuilds: Int = 1, beforeTimestamp: Long? = null) =
+        LogDownloader(apiConfig).getLastNBuilds(repo, branch, numberOfBuilds, beforeTimestamp).let { (response, repositoryApiResponse) ->
             if (response.status == HttpStatusCode.OK) {
                 repositoryApiResponse.data?.repository?.builds.let {
                     it ?: repositoryApiResponse.errors?.firstOrNull()?.let { e -> throw ApiException(response, e.message) }


### PR DESCRIPTION
The CirrusCI API is quite slow when loading the amount & type of data we are interested in. To avoid endless loading at the beginning, data is now loaded in smaller increments, displaying as soon as the first data has been loaded.