### PR TITLE
Improve Windows support

### DIFF
--- a/quirrus-core/src/main/kotlin/org/sonarsource/dev/quirrus/QuirrusConfig.kt
+++ b/quirrus-core/src/main/kotlin/org/sonarsource/dev/quirrus/QuirrusConfig.kt
@@ -1,0 +1,10 @@
+package org.sonarsource.dev.quirrus
+
+import java.nio.file.Path
+
+object QuirrusConfig {
+    val directory: Path = Path.of(
+        System.getenv("HOME") ?: System.getenv("userprofile"), 
+        ".quirrus"
+    )
+}

--- a/quirrus-core/src/main/kotlin/org/sonarsource/dev/quirrus/common/GenericCirrusCommand.kt
+++ b/quirrus-core/src/main/kotlin/org/sonarsource/dev/quirrus/common/GenericCirrusCommand.kt
@@ -8,6 +8,7 @@ import com.github.ajalt.clikt.parameters.types.int
 import com.github.ajalt.clikt.parameters.types.long
 import com.github.ajalt.clikt.parameters.types.path
 import org.sonarsource.dev.quirrus.CliLogger
+import org.sonarsource.dev.quirrus.QuirrusConfig
 import java.nio.file.Path
 
 abstract class GenericCirrusCommand : CliktCommand() {
@@ -30,7 +31,7 @@ abstract class GenericCirrusCommand : CliktCommand() {
         help = "You can store cirrus credentials (cirrusUserId and cirrusAuthToken) in a file and use that. This option will be used if " +
                 "no api token or cookies are provided explicitly."
     ).path(mustExist = false, canBeDir = false, mustBeReadable = true)
-        .default(Path.of(System.getenv("HOME"), ".quirrus", "auth.conf"))
+        .default(QuirrusConfig.directory.resolve("auth.conf"))
 
     val verbose by option("-v", "--verbose").flag(default = false)
 

--- a/wallboard/src/main/kotlin/com/sonarsource/dev/quirrus/wallboard/Main.kt
+++ b/wallboard/src/main/kotlin/com/sonarsource/dev/quirrus/wallboard/Main.kt
@@ -6,6 +6,7 @@ import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.WindowPlacement
 import androidx.compose.ui.window.WindowState
 import androidx.compose.ui.window.application
+import org.sonarsource.dev.quirrus.QuirrusConfig
 import org.sonarsource.dev.quirrus.api.ApiConfiguration
 import org.sonarsource.dev.quirrus.api.Authentication.authenticateWithConfigFile
 import java.nio.file.Path
@@ -15,7 +16,7 @@ val API_CONF = ApiConfiguration(
     requestTimeoutOverride = 30_000
 )
 
-val AUTH_CONF_FILE = Path.of(System.getenv("HOME"), ".quirrus", "auth.conf")
+val AUTH_CONF_FILE: Path = QuirrusConfig.directory.resolve("auth.conf")
 
 private const val MIN_WINDOW_WIDTH = 1400
 private const val MIN_WINDOW_HEIGHT = 900

--- a/wallboard/src/main/kotlin/com/sonarsource/dev/quirrus/wallboard/WallboardConfig.kt
+++ b/wallboard/src/main/kotlin/com/sonarsource/dev/quirrus/wallboard/WallboardConfig.kt
@@ -1,6 +1,6 @@
 package com.sonarsource.dev.quirrus.wallboard
 
-import java.nio.file.Path
+import org.sonarsource.dev.quirrus.QuirrusConfig
 import kotlin.io.path.createDirectories
 import kotlin.io.path.createFile
 import kotlin.io.path.exists
@@ -9,7 +9,7 @@ import kotlin.io.path.readText
 import kotlin.io.path.writeText
 
 object WallboardConfig {
-    private val configFile = Path.of(System.getenv("HOME"), ".quirrus", "branches.conf").also { file ->
+    private val configFile = QuirrusConfig.directory.resolve("branches.conf").also { file ->
         if (!file.parent.exists()) {
             file.parent.createDirectories()
         }


### PR DESCRIPTION
Fallback to `userprofile` environment variable if `HOME` is not present.

This allows Windows users to run Quirrus out of the box.